### PR TITLE
20230417 adds `Provable` interface to `MerkleTree`

### DIFF
--- a/circuit-tree-generation/src/lib.rs
+++ b/circuit-tree-generation/src/lib.rs
@@ -11,9 +11,9 @@ use plonky2::{
 };
 use tree_circuit_generation::add_merkle_root_target;
 
-pub mod tests;
-pub mod tree_circuit_generation;
-pub mod utils;
+mod tests;
+mod tree_circuit_generation;
+mod utils;
 
 pub trait Provable<F: RichField + Extendable<D>, const D: usize> {
     type Value;

--- a/circuit-tree-generation/src/lib.rs
+++ b/circuit-tree-generation/src/lib.rs
@@ -1,3 +1,102 @@
+use anyhow::anyhow;
+use plonky2::{
+    field::extension::Extendable,
+    hash::hash_types::RichField,
+    hash::{hash_types::HashOutTarget, merkle_tree::MerkleTree},
+    iop::{
+        target::Target,
+        witness::{PartialWitness, WitnessWrite},
+    },
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        config::{AlgebraicHasher, GenericHashOut, Hasher},
+    },
+};
+use tree_generation::add_merkle_root_target;
+
 pub mod tests;
 pub mod tree_generation;
 pub mod utils;
+
+pub trait Provable<F: RichField + Extendable<D>, const D: usize> {
+    type Value;
+    type Targets;
+    type OutTargets;
+
+    fn evaluate(&self) -> Self::Value;
+    fn compile(
+        &self,
+        circuit_builder: &mut CircuitBuilder<F, D>,
+    ) -> (Self::Targets, Self::OutTargets);
+    fn fill(
+        &self,
+        partial_witness: &mut PartialWitness<F>,
+        targets: Self::Targets,
+    ) -> Result<(), anyhow::Error>;
+    fn compile_and_fill(
+        &self,
+        circuit_builder: &mut CircuitBuilder<F, D>,
+        partial_witness: &mut PartialWitness<F>,
+        targets: Self::Targets,
+    ) -> Result<(), anyhow::Error> {
+        self.compile(circuit_builder);
+        self.fill(partial_witness, targets)
+    }
+}
+
+impl<F: RichField + Extendable<D>, const D: usize, H: AlgebraicHasher<F>> Provable<F, D>
+    for MerkleTree<F, H>
+{
+    type Value = H::Hash;
+    type Targets = Vec<Vec<Target>>;
+    type OutTargets = HashOutTarget;
+
+    fn evaluate(&self) -> Self::Value {
+        // for now, we only allow cap == 0
+        if self.cap.len() != 1 {
+            panic!("Invalid cap, for now cap == 0")
+        }
+        self.cap.0[0]
+    }
+
+    fn compile(
+        &self,
+        circuit_builder: &mut CircuitBuilder<F, D>,
+    ) -> (Self::Targets, Self::OutTargets) {
+        let targets = self
+            .leaves
+            .iter()
+            .map(|l| circuit_builder.add_virtual_targets(l.len()))
+            .collect::<Vec<_>>();
+        let to_extend_target = circuit_builder.zero();
+        let out_target =
+            add_merkle_root_target::<F, D, H>(circuit_builder, targets.clone(), to_extend_target);
+        (targets, out_target)
+    }
+
+    fn fill(
+        &self,
+        partial_witness: &mut PartialWitness<F>,
+        targets: Self::Targets,
+    ) -> Result<(), anyhow::Error> {
+        if targets.len() != self.leaves.len() {
+            return Err(anyhow!("Invalid target lenghts"));
+        }
+        targets
+            .iter()
+            .zip(&self.leaves)
+            .map(|(vec_target, leaf)| {
+                if vec_target.len() != leaf.len() {
+                    Err(anyhow!("Invalid leaf targets length"))
+                } else {
+                    vec_target
+                        .iter()
+                        .zip(leaf)
+                        .for_each(|(t, l)| partial_witness.set_target(*t, *l));
+                    Ok(())
+                }
+            })
+            .collect::<Result<(), _>>()?;
+        Ok(())
+    }
+}

--- a/circuit-tree-generation/src/tree_circuit_generation.rs
+++ b/circuit-tree-generation/src/tree_circuit_generation.rs
@@ -3,10 +3,7 @@ use plonky2::{
     field::extension::Extendable,
     hash::hash_types::{HashOutTarget, RichField},
     iop::target::Target,
-    plonk::{
-        circuit_builder::CircuitBuilder,
-        config::{AlgebraicHasher, Hasher},
-    },
+    plonk::{circuit_builder::CircuitBuilder, config::AlgebraicHasher},
 };
 
 pub(crate) fn add_merkle_root_target<

--- a/circuit-tree-generation/src/tree_generation.rs
+++ b/circuit-tree-generation/src/tree_generation.rs
@@ -1,58 +1,48 @@
 use crate::utils::extend_targets_to_power_of_two;
 use plonky2::{
     field::extension::Extendable,
-    hash::{
-        hash_types::{HashOutTarget, RichField},
-        poseidon::PoseidonHash,
-    },
+    hash::hash_types::{HashOutTarget, RichField},
     iop::target::Target,
-    plonk::circuit_builder::CircuitBuilder,
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        config::{AlgebraicHasher, Hasher},
+    },
 };
 
-pub trait MerkleTreeGeneration<F: RichField + Extendable<D>, const D: usize> {
-    type Hasher;
-    fn add_merkle_root_target(
-        &mut self,
-        targets: Vec<Vec<Target>>,
-        to_extend_target: Target,
-    ) -> HashOutTarget;
-}
-
-impl<F: RichField + Extendable<D>, const D: usize> MerkleTreeGeneration<F, D>
-    for CircuitBuilder<F, D>
-{
-    type Hasher = PoseidonHash;
-    fn add_merkle_root_target(
-        &mut self,
-        targets: Vec<Vec<Target>>,
-        to_extend_target: Target,
-    ) -> HashOutTarget {
-        // extend `targets` to a length of power of two vector
-        let targets = extend_targets_to_power_of_two(self, targets, to_extend_target);
-        // build the merkle tree root target
-        let merkle_tree_height = targets.len().ilog2();
-        let mut tree_hash_targets = vec![];
-        for i in 0..targets.len() {
-            let hash_target = self.hash_or_noop::<Self::Hasher>(targets[i].clone());
-            tree_hash_targets.push(hash_target);
-        }
-        let mut current_tree_height_index = 0;
-        let mut i = 0;
-        for height in 0..merkle_tree_height {
-            // TODO: do we want to loop over all the height, or until cap(1) ?
-            while i < current_tree_height_index + (1 << (merkle_tree_height - height)) {
-                let hash_targets = self.hash_n_to_hash_no_pad::<Self::Hasher>(
-                    [
-                        tree_hash_targets[i as usize].elements.clone(),
-                        tree_hash_targets[i as usize + 1].elements.clone(),
-                    ]
-                    .concat(),
-                );
-                tree_hash_targets.push(hash_targets);
-                i += 2;
-            }
-            current_tree_height_index += 1 << (merkle_tree_height - height);
-        }
-        *tree_hash_targets.last().unwrap()
+pub(crate) fn add_merkle_root_target<
+    F: RichField + Extendable<D>,
+    const D: usize,
+    H: AlgebraicHasher<F>,
+>(
+    circuit_builder: &mut CircuitBuilder<F, D>,
+    targets: Vec<Vec<Target>>,
+    to_extend_target: Target,
+) -> HashOutTarget {
+    // extend `targets` to a length of power of two vector
+    let targets = extend_targets_to_power_of_two(circuit_builder, targets, to_extend_target);
+    // build the merkle tree root target
+    let merkle_tree_height = targets.len().ilog2();
+    let mut tree_hash_targets = vec![];
+    for i in 0..targets.len() {
+        let hash_target = circuit_builder.hash_or_noop::<H>(targets[i].clone());
+        tree_hash_targets.push(hash_target);
     }
+    let mut current_tree_height_index = 0;
+    let mut i = 0;
+    for height in 0..merkle_tree_height {
+        // TODO: do we want to loop over all the height, or until cap(1) ?
+        while i < current_tree_height_index + (1 << (merkle_tree_height - height)) {
+            let hash_targets = circuit_builder.hash_n_to_hash_no_pad::<H>(
+                [
+                    tree_hash_targets[i as usize].elements.clone(),
+                    tree_hash_targets[i as usize + 1].elements.clone(),
+                ]
+                .concat(),
+            );
+            tree_hash_targets.push(hash_targets);
+            i += 2;
+        }
+        current_tree_height_index += 1 << (merkle_tree_height - height);
+    }
+    *tree_hash_targets.last().unwrap()
 }

--- a/circuit-tree-generation/src/utils.rs
+++ b/circuit-tree-generation/src/utils.rs
@@ -32,60 +32,11 @@ pub fn extend_targets_to_power_of_two<F: RichField + Extendable<D>, const D: usi
     targets
 }
 
-pub(crate) fn extend_to_power_of_two<F: RichField + Extendable<D>, const D: usize>(
-    mut values: Vec<Vec<F>>,
-    to_extend_value: F,
-) -> Vec<Vec<F>> {
-    let log_2_len = values.len().ilog2();
-    if 2_u64.pow(log_2_len) == values.len() as u64 {
-        return values;
-    }
-    let diff = 2_u64.pow(log_2_len + 1) - values.len() as u64 - 1;
-
-    // append length of `values`
-    values.push(vec![F::from_canonical_u64(values.len() as u64)]);
-    // trivially extend the vector until we obtain a power 2 length output vector
-    let to_extend_values = vec![vec![to_extend_value]; diff as usize];
-    values.extend(to_extend_values);
-    values
-}
-
-fn merkle_root<F: RichField + Extendable<D>, const D: usize>(
-    leaves: Vec<Vec<F>>,
-) -> Vec<HashOut<F>> {
-    // extend `targets` to a length of power of two vector
-    let leaves = extend_to_power_of_two::<F, D>(leaves, F::ZERO);
-    // build the merkle tree root target
-    let merkle_tree_height = leaves.len().ilog2();
-    let mut tree_hash_leaves = vec![];
-    for i in 0..leaves.len() {
-        let hash = PoseidonHash::hash_or_noop(&leaves[i]);
-        tree_hash_leaves.push(hash);
-    }
-    let mut current_tree_height_index = 0;
-    let mut i = 0;
-    for height in 0..merkle_tree_height {
-        // TODO: do we want to loop over all the height, or until cap(1) ?
-        while i < current_tree_height_index + (1 << (merkle_tree_height - height)) {
-            let hash = PoseidonHash::hash_no_pad(
-                &[
-                    tree_hash_leaves[i as usize].elements.clone(),
-                    tree_hash_leaves[i as usize + 1].elements.clone(),
-                ]
-                .concat(),
-            );
-            tree_hash_leaves.push(hash);
-            i += 2;
-        }
-        current_tree_height_index += 1 << (merkle_tree_height - height);
-    }
-    tree_hash_leaves
-}
-
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
 
     use super::*;
+    use crate::tests::extend_to_power_of_two;
     use plonky2::{
         field::{goldilocks_field::GoldilocksField, types::Field},
         hash::merkle_tree::MerkleTree,
@@ -93,6 +44,38 @@ mod tests {
 
     type F = GoldilocksField;
     const D: usize = 2;
+
+    fn merkle_root<F: RichField + Extendable<D>, const D: usize>(
+        leaves: Vec<Vec<F>>,
+    ) -> Vec<HashOut<F>> {
+        // extend `targets` to a length of power of two vector
+        let leaves = extend_to_power_of_two::<F, D>(leaves, F::ZERO);
+        // build the merkle tree root target
+        let merkle_tree_height = leaves.len().ilog2();
+        let mut tree_hash_leaves = vec![];
+        for i in 0..leaves.len() {
+            let hash = PoseidonHash::hash_or_noop(&leaves[i]);
+            tree_hash_leaves.push(hash);
+        }
+        let mut current_tree_height_index = 0;
+        let mut i = 0;
+        for height in 0..merkle_tree_height {
+            // TODO: do we want to loop over all the height, or until cap(1) ?
+            while i < current_tree_height_index + (1 << (merkle_tree_height - height)) {
+                let hash = PoseidonHash::hash_no_pad(
+                    &[
+                        tree_hash_leaves[i as usize].elements.clone(),
+                        tree_hash_leaves[i as usize + 1].elements.clone(),
+                    ]
+                    .concat(),
+                );
+                tree_hash_leaves.push(hash);
+                i += 2;
+            }
+            current_tree_height_index += 1 << (merkle_tree_height - height);
+        }
+        tree_hash_leaves
+    }
 
     #[test]
     fn test_merkle_root() {

--- a/circuit-tree-generation/src/utils.rs
+++ b/circuit-tree-generation/src/utils.rs
@@ -1,11 +1,6 @@
 use plonky2::{
-    field::extension::Extendable,
-    hash::{
-        hash_types::{HashOut, RichField},
-        poseidon::PoseidonHash,
-    },
-    iop::target::Target,
-    plonk::{circuit_builder::CircuitBuilder, config::Hasher},
+    field::extension::Extendable, hash::hash_types::RichField, iop::target::Target,
+    plonk::circuit_builder::CircuitBuilder,
 };
 
 /// Extends a given vector of `Target`s of a certain length len
@@ -34,12 +29,19 @@ pub fn extend_targets_to_power_of_two<F: RichField + Extendable<D>, const D: usi
 
 #[cfg(test)]
 pub(crate) mod tests {
-
-    use super::*;
     use crate::tests::extend_to_power_of_two;
     use plonky2::{
         field::{goldilocks_field::GoldilocksField, types::Field},
         hash::merkle_tree::MerkleTree,
+        plonk::config::Hasher,
+    };
+
+    use plonky2::{
+        field::extension::Extendable,
+        hash::{
+            hash_types::{HashOut, RichField},
+            poseidon::PoseidonHash,
+        },
     };
 
     type F = GoldilocksField;


### PR DESCRIPTION
In this PR, we refactor the construction of `Merkle Tree` roots for `CircuitBuilder`.  Instead of implementing the logic directly on a `CircuitBuilder` instance, we make it depend on the `MerkleTree` struct itself, which abstracts away the need to have to deal with a `builder` directly. 

Even though not similar, this work is inspired by Biscoitti work on Plonky2 DSL.